### PR TITLE
feat: ESLint設定をCLI形式に移行しESM形式に統一

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals"]
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import { FlatCompat } from "@eslint/eslintrc";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const config = [
+  ...compat.extends("next/core-web-vitals"),
+  ...compat.extends("next/typescript"),
+  {
+    ignores: [
+      ".next/**",
+      "node_modules/**",
+      "out/**",
+      "public/**",
+      "*.config.js",
+      "*.config.ts",
+      "next-env.d.ts"
+    ],
+  },
+];
+
+export default config;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,8 +18,6 @@ const config = [
       "node_modules/**",
       "out/**",
       "public/**",
-      "*.config.js",
-      "*.config.ts",
       "next-env.d.ts"
     ],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,4 @@ const nextConfig = {
   typedRoutes: true,
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kat-log-portfolio",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -19,6 +19,7 @@
     "tailwindcss": "^4.1.13"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@types/node": "^24.3.1",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^4.1.13
         version: 4.1.13
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@types/node':
         specifier: ^24.3.1
         version: 24.3.1

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
+import typography from "@tailwindcss/typography";
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -13,5 +15,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/typography")],
-}
+  plugins: [typography],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 import typography from "@tailwindcss/typography";
 
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -17,3 +17,5 @@ export default {
   },
   plugins: [typography],
 };
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,19 +19,10 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "target": "ES2017"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
## 概要
ESLint設定を従来の.eslintrc.jsonからeslint.config.js（CLI形式）に移行し、プロジェクト全体をESM形式に統一しました。

## 変更内容
- ESLint設定を.eslintrc.jsonからeslint.config.jsに移行
- package.jsonにtype: "module"を追加してESM形式を有効化
- next.config.jsをCommonJS形式からESM形式に変更
- tailwind.config.jsをESM形式に修正
- tsconfig.jsonのexcludeに'.next'を追加

## ファイル変更統計
- 7ファイル変更、45行追加、26行削除
- .eslintrc.json削除、eslint.config.js新規作成

## テスト
設定変更後もlintコマンドが正常に動作することを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)