### PR TITLE
add: Husky セットアップ - mainブランチへの直コミット禁止

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" = "main" ]; then
+  echo "❌ mainブランチへの直接コミットは禁止されています！"
+  echo "📝 新しいブランチを作成してからコミットしてください。"
+  echo ""
+  echo "  git checkout -b feat/your-feature"
+  echo ""
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "prepare": "husky"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -53,6 +54,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^15.5.9",
     "eslint-plugin-storybook": "^10.2.0",
+    "husky": "^9.1.7",
     "playwright": "^1.57.0",
     "postcss": "^8.5.6",
     "storybook": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       eslint-plugin-storybook:
         specifier: ^10.2.0
         version: 10.2.0(eslint@9.39.2(jiti@1.21.7))(storybook@10.2.0(@testing-library/dom@10.4.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       playwright:
         specifier: ^1.57.0
         version: 1.57.0
@@ -2197,6 +2200,11 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5556,6 +5564,8 @@ snapshots:
       function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary
- mainブランチへの直接コミットを防止するHuskyのpre-commitフックを導入

## Changes
- Husky v9 をインストール
- pre-commit フックで現在のブランチをチェックし、mainの場合はコミットをブロック

## Files Changed
- `.husky/pre-commit`: mainブランチ検出とブロックスクリプト
- `package.json`: husky devDependency と prepare スクリプト追加
- `pnpm-lock.yaml`: lockfile 更新