### PR TITLE
fix: pre-commit メッセージを git switch -c に変更

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ if [ "$branch" = "main" ]; then
   echo "❌ mainブランチへの直接コミットは禁止されています！"
   echo "📝 新しいブランチを作成してからコミットしてください。"
   echo ""
-  echo "  git checkout -b feat/your-feature"
+  echo "  git switch -c feat/your-feature"
   echo ""
   exit 1
 fi


### PR DESCRIPTION
## Summary
- pre-commit フックのエラーメッセージで `git checkout -b` を `git switch -c` に変更

## Reason
- `git switch` は Git 2.23 で導入された新しいコマンド
- ブランチ操作に特化しており、より直感的