### PR TITLE
update: CIでE2E/Lighthouse/Buildをソースコード変更時のみ実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -12,6 +13,35 @@ on:
       - main
 
 jobs:
+  # ソースコード変更を検出（E2E/Lighthouse/Buildのスキップ判定用）
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'app/**'
+              - 'components/**'
+              - 'data/**'
+              - 'types/**'
+              - 'public/**'
+              - 'lib/**'
+              - 'e2e/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'next.config.*'
+              - 'playwright.config.*'
+              - 'tsconfig.json'
+              - 'tailwind.config.*'
+              - 'postcss.config.*'
+              - 'lighthouserc.*'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -63,6 +93,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -95,6 +127,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -130,7 +164,8 @@ jobs:
   lighthouse:
     name: Lighthouse CI
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, changes]
+    if: needs.changes.outputs.src == 'true' && needs.build.result == 'success'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- dorny/paths-filterを使用してソースコード変更を検出
- READMEやdocs変更のみの場合は重いジョブ（E2E/Lighthouse/Build）をスキップ
- GitHub Actions無料枠の効率的な活用を実現

## Changes
- `changes`ジョブ追加（パス変更検出）
- `build`/`e2e-tests`/`lighthouse`に`needs: changes` + `if`条件追加
- `lighthouse`にbuild成功チェック追加（`needs.build.result == 'success'`）

## Files Changed
- `.github/workflows/ci.yml`: paths-filter導入、条件分岐追加

## スキップ対象パス以外（E2Eが走るケース）
- `app/**`, `components/**`, `data/**`, `types/**`, `public/**`, `lib/**`, `e2e/**`
- `package.json`, `pnpm-lock.yaml`, `next.config.*`, `playwright.config.*`
- `tsconfig.json`, `tailwind.config.*`, `postcss.config.*`, `lighthouserc.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)