### PR TITLE
fix: Heroタイトルの'g'下部が見切れる問題を修正

### DIFF
--- a/components/features/HeroSection.tsx
+++ b/components/features/HeroSection.tsx
@@ -76,7 +76,7 @@ export function HeroSection() {
         {/* メインタイトル */}
         <motion.h1
           variants={itemVariants}
-          className="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 dark:from-blue-400 dark:via-purple-400 dark:to-pink-400 bg-clip-text text-transparent"
+          className="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 pb-2 bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 dark:from-blue-400 dark:via-purple-400 dark:to-pink-400 bg-clip-text text-transparent"
         >
           Welcome to Kat Log Portfolio
         </motion.h1>


### PR DESCRIPTION
## Summary
- HeroセクションのメインタイトルでDescender（g, y等の下に伸びる部分）が見切れる問題を修正
- `bg-clip-text` + `text-transparent` 使用時に `line-height: 1` でテキスト描画領域が不足していたため、`pb-2` を追加してスペースを確保

## Test plan
- [x] ブラウザで 'g' のdescender が正しく表示されることを確認済み
- [x] `pnpm lint` パス（既存warningのみ）
- [x] `pnpm type-check` パス
- [x] `pnpm build` パス

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)