### PR TITLE
feat: ファビコンを設定する (#85)

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 180,
+  height: 180,
+}
+export const contentType = 'image/png'
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #2563eb, #9333ea, #ec4899)',
+          borderRadius: '36px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: '120px',
+            fontWeight: 700,
+            color: 'white',
+            lineHeight: 1,
+          }}
+        >
+          K
+        </span>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,39 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 32,
+  height: 32,
+}
+export const contentType = 'image/png'
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #2563eb, #9333ea, #ec4899)',
+          borderRadius: '6px',
+        }}
+      >
+        <span
+          style={{
+            fontSize: '22px',
+            fontWeight: 700,
+            color: 'white',
+            lineHeight: 1,
+          }}
+        >
+          K
+        </span>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  )
+}


### PR DESCRIPTION
## Summary
ポートフォリオサイトにファビコンとApple Touch Iconを追加。ブラウザタブやブックマークでサイトを識別しやすくする。

## Changes
- Next.js App Routerのファイルベース規約で動的にアイコンを生成
- サイトのグラデーションテーマ（blue → purple → pink）に合わせた「K」ロゴデザイン

## Files Changed
- `app/icon.tsx`: ファビコン（32×32）の動的生成
- `app/apple-icon.tsx`: Apple Touch Icon（180×180）の動的生成

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)