### PR TITLE
chore: Claude Code許可リストにgh pr view/diff/checksを追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,10 @@
       "mcp__playwright__browser_close",
       "mcp__playwright__browser_take_screenshot",
       "mcp__playwright__browser_press_key",
-      "WebFetch(domain:amaguri-2bro-gallery.kat-log.workers.dev)"
+      "WebFetch(domain:amaguri-2bro-gallery.kat-log.workers.dev)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary
- Claude Codeのallow設定に `gh pr checks`、`gh pr view`、`gh pr diff` を追加

## Changes
- いずれも読み取り専用コマンドで、PRの状態確認・差分表示に使用

## Files Changed
- `.claude/settings.local.json`: 許可リストに3コマンドを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)