### PR TITLE
chore: サンプルデータの残存設定・ディレクトリを削除

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,13 +5,6 @@ import withBundleAnalyzer from '@next/bundle-analyzer'
 const nextConfig = {
   typedRoutes: true,
   images: {
-    // 外部画像ホストの許可
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'placehold.co',
-      },
-    ],
     // 画像最適化設定
     formats: ['image/avif', 'image/webp'], // AVIF優先、次にWebP
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840], // レスポンシブ画像のブレークポイント


### PR DESCRIPTION
## Summary
- `next.config.js` から未使用の `placehold.co` remotePatterns設定を削除
- 空のサンプルプロジェクト画像ディレクトリ（`e-commerce/`, `task-manager/`, `extension/`）を削除

Refs #42

## Test plan
- [x] `pnpm build` が成功すること
- [x] 画像表示に影響がないこと（全プロジェクトはローカル画像を使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)