### PR TITLE
feat: Google Analytics 4 (GA4) を導入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ NEXT_PUBLIC_SENTRY_DSN=https://xxxxx@xxxxx.ingest.sentry.io/xxxxx
 SENTRY_ORG=your-org-name
 SENTRY_PROJECT=your-project-name
 SENTRY_AUTH_TOKEN=your-auth-token
+
+# Google Analytics 4
+# https://analytics.google.com で測定IDを取得してください
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Footer } from '@/components/layout/Footer'
 import { ThemeProvider } from '@/components/providers/ThemeProvider'
 import { PageTransition } from '@/components/providers/PageTransition'
 import { Analytics } from '@vercel/analytics/react'
+import { GoogleAnalytics } from '@next/third-parties/google'
 
 // 英語フォント（Inter）の設定
 const inter = Inter({
@@ -102,6 +103,9 @@ export default function RootLayout({
           <Footer />
         </ThemeProvider>
         <Analytics />
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
       </body>
     </html>
   )

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -233,6 +233,11 @@
   - Chrome Web Storeからスクリーンショット2枚を取得・配置
   - type: extension、tags: extension/personal、store + github リンク設定
 
+- ✅ **Google Analytics 4 (GA4) 導入** (2026-03-02 完了, Issue #104)
+  - `@next/third-parties/google`のGoogleAnalyticsコンポーネント導入
+  - 環境変数（NEXT_PUBLIC_GA_ID）による測定ID管理
+  - Vercel Analyticsと併用（パフォーマンス計測 + ユーザー行動分析）
+
 ### 将来の拡張機能（MVP 後）
 
 - EmailJS を使ったお問い合わせフォーム
@@ -276,8 +281,8 @@ pnpm type-check
 
 ---
 
-**最終更新**: 2026-02-27
-**バージョン**: 1.26.0
+**最終更新**: 2026-03-02
+**バージョン**: 1.27.0
 
 ## 進捗状況サマリー
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@next/third-parties": "^16.1.6",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/nextjs": "^10.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: ^16.1.6
+        version: 16.1.6(next@16.1.5(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -896,6 +899,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.1.6':
+    resolution: {integrity: sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4757,6 +4766,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   third-party-web@0.26.7:
     resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
 
@@ -5881,6 +5893,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.5':
     optional: true
+
+  '@next/third-parties@16.1.6(next@16.1.5(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      next: 16.1.5(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -10284,6 +10302,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  third-party-capital@1.0.20: {}
 
   third-party-web@0.26.7: {}
 


### PR DESCRIPTION
## Summary
- `@next/third-parties/google` の `GoogleAnalytics` コンポーネントを導入
- 環境変数 `NEXT_PUBLIC_GA_ID` で測定IDを管理（未設定時はGA4スクリプトを読み込まない）
- Vercel Analytics（パフォーマンス計測）と併用し、GA4でユーザー行動・流入元を分析

## Files Changed
- `app/layout.tsx`: GoogleAnalytics コンポーネントを追加
- `package.json` / `pnpm-lock.yaml`: `@next/third-parties` を追加
- `.env.example`: GA4環境変数のテンプレートを追加
- `docs/development-plan.md`: GA4導入を完了済み拡張機能に記録

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)