### PR TITLE
feat: ファビコンのカラーをミントグリーンテーマに統一

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -16,7 +16,7 @@ export default function AppleIcon() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'linear-gradient(135deg, #2563eb, #9333ea, #ec4899)',
+          background: 'linear-gradient(135deg, #247e75, #3aafa9)',
           borderRadius: '36px',
         }}
       >

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -16,7 +16,7 @@ export default function Icon() {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          background: 'linear-gradient(135deg, #2563eb, #9333ea, #ec4899)',
+          background: 'linear-gradient(135deg, #247e75, #3aafa9)',
           borderRadius: '6px',
         }}
       >


### PR DESCRIPTION
## Summary
- ファビコン(`app/icon.tsx`)と Appleアイコン(`app/apple-icon.tsx`)の背景グラデーションを旧カラー(青/紫/ピンク `#2563eb, #9333ea, #ec4899`)からミントグリーン(`#247e75 → #3aafa9`)に変更
- OG画像(#112)およびサイト全体のカラーテーマ(#111)と統一

Refs #111

## Test plan
- [ ] `pnpm dev` でブラウザタブのファビコンがミントグリーンになっていることを確認
- [ ] Appleデバイスのホーム画面アイコンがミントグリーンになっていることを確認（または `/apple-icon` エンドポイントで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)