### PR TITLE
feat: ずんだもんボイス読み上げをfeaturedに変更し、LPリンクを追加

### DIFF
--- a/components/features/FeaturedProjects.tsx
+++ b/components/features/FeaturedProjects.tsx
@@ -178,7 +178,25 @@ export function FeaturedProjects({ projects, onProjectClick }: FeaturedProjectsP
                           href={project.links.demo || project.links.store || '#'}
                           target="_blank"
                           rel="noopener noreferrer"
-                          aria-label="Demo"
+                          aria-label="サイトを見る"
+                        >
+                          <ExternalLink className="h-5 w-5" />
+                        </a>
+                      </Button>
+                    )}
+
+                    {project.links?.lp && (
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        asChild
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <a
+                          href={project.links.lp}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label="紹介ページ"
                         >
                           <ExternalLink className="h-5 w-5" />
                         </a>

--- a/components/features/ProjectCard.tsx
+++ b/components/features/ProjectCard.tsx
@@ -173,7 +173,26 @@ export function ProjectCard({ project, onClick }: ProjectCardProps) {
                 rel="noopener noreferrer"
               >
                 <ExternalLink className="w-4 h-4 mr-2" />
-                Demo
+                サイトを見る
+              </Link>
+            </Button>
+          )}
+
+          {project.links.lp && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex-1"
+              asChild
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Link
+                href={project.links.lp}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="w-4 h-4 mr-2" />
+                紹介ページ
               </Link>
             </Button>
           )}

--- a/components/features/ProjectModal.tsx
+++ b/components/features/ProjectModal.tsx
@@ -259,7 +259,20 @@ export function ProjectModal({ project, isOpen, onClose, isLoading = false }: Pr
                     rel="noopener noreferrer"
                   >
                     <ExternalLink className="w-5 h-5 mr-2" />
-                    デモを見る
+                    サイトを見る
+                  </Link>
+                </Button>
+              )}
+
+              {project.links.lp && (
+                <Button variant="default" size="lg" asChild>
+                  <Link
+                    href={project.links.lp}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="w-5 h-5 mr-2" />
+                    紹介ページ
                   </Link>
                 </Button>
               )}

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -21,7 +21,7 @@ export const projects: Project[] = [
       { url: '/images/projects/amaguri/gallery.png', alt: 'ギャラリーページ' },
       { url: '/images/projects/amaguri/about.png', alt: 'アバウトページ' }
     ],
-    featured: true,
+    featured: false,
     date: '2025-12',
     status: 'completed'
   },
@@ -61,7 +61,9 @@ export const projects: Project[] = [
     },
     links: {
       store:
-        'https://chromewebstore.google.com/detail/youtube%E3%83%A9%E3%82%A4%E3%83%96%E3%83%81%E3%83%A3%E3%83%83%E3%83%88%E3%81%9A%E3%82%93%E3%81%A0%E3%82%82%E3%82%93%E3%83%9C%E3%82%A4%E3%82%B9%E8%AA%AD%E3%81%BF%E4%B8%8A/gdakacmdogbakjhalfjkclkagdojhooi'
+        'https://chromewebstore.google.com/detail/youtube%E3%83%A9%E3%82%A4%E3%83%96%E3%83%81%E3%83%A3%E3%83%83%E3%83%88%E3%81%9A%E3%82%93%E3%81%A0%E3%82%82%E3%82%93%E3%83%9C%E3%82%A4%E3%82%B9%E8%AA%AD%E3%81%BF%E4%B8%8A/gdakacmdogbakjhalfjkclkagdojhooi',
+      github: 'https://github.com/kat-log/youtube-voicevox-standalone',
+      lp: 'https://kat-log.github.io/youtube-voicevox-standalone/'
     },
     screenshots: [
       { url: '/images/projects/youtube-voicevox/screenshot1.png', alt: 'メイン紹介画像' },
@@ -69,8 +71,8 @@ export const projects: Project[] = [
       { url: '/images/projects/youtube-voicevox/screenshot3.png', alt: '設定画面' },
       { url: '/images/projects/youtube-voicevox/screenshot4.png', alt: '詳細設定画面' }
     ],
-    featured: false,
-    date: '2025-08',
+    featured: true,
+    date: '2026-04',
     status: 'completed'
   },
   {

--- a/types/index.ts
+++ b/types/index.ts
@@ -80,6 +80,7 @@ export interface TechnologyStack {
 export interface ProjectLinks {
   github?: string;
   demo?: string;
+  lp?: string;
   store?: string;
   article?: string; // Qiitaやブログ記事など
   video?: string; // デモ動画など


### PR DESCRIPTION
## 変更内容

- ずんだもんボイス読み上げを featured プロジェクトに変更（2BRO推し活ギャラリーを featured から外す）
- ずんだもんボイス読み上げに GitHub・LP リンクを追加
- `ProjectLinks` 型に `lp` フィールドを追加
- ボタンラベルを「Demo / デモを見る」→「サイトを見る」に変更
- LP リンク用の「紹介ページ」ボタンを追加（ProjectCard / ProjectModal / FeaturedProjects）
- ずんだもんボイス読み上げの日付を 2026-04 に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)