### PR TITLE
refactor: SNSプラットフォーム設定をlib/social-platforms.tsに一元化

### DIFF
--- a/components/features/AboutSection.tsx
+++ b/components/features/AboutSection.tsx
@@ -1,22 +1,15 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { siGithub, siX, siQiita } from 'simple-icons'
-import { Profile, SocialPlatform } from '@/types'
+import { Profile } from '@/types'
 // TODO: スキルセクション復活時にコメント解除
 // import { SkillCard } from './SkillCard'
 import { Button } from '@/components/ui/button'
+import { SOCIAL_PLATFORM_CONFIG } from '@/lib/social-platforms'
 
 interface AboutSectionProps {
   profile: Profile
   showAllSkills?: boolean // スキルを全て表示するか、主要なものだけか
-}
-
-// SNSプラットフォームとアイコンのマッピング
-const socialIcons: Partial<Record<SocialPlatform, typeof siGithub>> = {
-  github: siGithub,
-  x: siX,
-  qiita: siQiita,
 }
 
 // コンテナのアニメーション設定
@@ -82,8 +75,8 @@ export function AboutSection({ profile, showAllSkills = false }: AboutSectionPro
           {/* SNSリンク */}
           <div className="flex flex-wrap justify-center gap-3">
             {profile.socialLinks.map((social) => {
-              const icon = socialIcons[social.platform]
-              if (!icon) return null
+              const config = SOCIAL_PLATFORM_CONFIG[social.platform]
+              if (!config) return null
               return (
                 <Button
                   key={social.platform}
@@ -96,15 +89,15 @@ export function AboutSection({ profile, showAllSkills = false }: AboutSectionPro
                     href={social.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    aria-label={`${social.platform} - ${social.username}`}
+                    aria-label={`${config.label} - ${social.username}`}
                   >
                     <div
                       className="h-4 w-4"
-                      dangerouslySetInnerHTML={{ __html: icon.svg }}
+                      dangerouslySetInnerHTML={{ __html: config.icon.svg }}
                       style={{ fill: 'currentColor' }}
                     />
                     <span className="hidden sm:inline">{social.username}</span>
-                    <span className="sm:hidden capitalize">{social.platform}</span>
+                    <span className="sm:hidden">{config.label}</span>
                   </a>
                 </Button>
               )

--- a/components/features/SocialLinks.tsx
+++ b/components/features/SocialLinks.tsx
@@ -1,21 +1,9 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { siGithub, siX, siQiita } from 'simple-icons'
 import { Button } from '@/components/ui/button'
-
-type SocialPlatform = 'github' | 'x' | 'qiita'
-
-const socialIcons: Record<SocialPlatform, typeof siGithub> = {
-  github: siGithub,
-  x: siX,
-  qiita: siQiita,
-}
-
-interface SocialLink {
-  platform: string
-  url: string
-}
+import { SOCIAL_PLATFORM_CONFIG } from '@/lib/social-platforms'
+import type { SocialLink } from '@/types'
 
 interface SocialLinksProps {
   links: SocialLink[]
@@ -25,7 +13,8 @@ export function SocialLinks({ links }: SocialLinksProps) {
   return (
     <div className="flex flex-wrap gap-4">
       {links.map((link) => {
-        const icon = socialIcons[link.platform as SocialPlatform]
+        const config = SOCIAL_PLATFORM_CONFIG[link.platform]
+        if (!config) return null
 
         return (
           <motion.div
@@ -47,10 +36,10 @@ export function SocialLinks({ links }: SocialLinksProps) {
               >
                 <div
                   className="w-5 h-5 flex-shrink-0 [&>svg]:w-full [&>svg]:h-full"
-                  dangerouslySetInnerHTML={{ __html: icon.svg }}
+                  dangerouslySetInnerHTML={{ __html: config.icon.svg }}
                   style={{ fill: 'currentColor' }}
                 />
-                <span className="uppercase">{link.platform}</span>
+                <span>{config.label}</span>
               </a>
             </Button>
           </motion.div>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,18 +1,10 @@
 import Link from "next/link";
 import { Mail } from "lucide-react";
-import { siGithub, siX, siQiita } from "simple-icons";
 import { profile } from "@/data/profile";
-
-type SocialPlatform = 'github' | 'x' | 'qiita';
+import { SOCIAL_PLATFORM_CONFIG } from "@/lib/social-platforms";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
-
-  const socialIcons: Record<SocialPlatform, typeof siGithub> = {
-    github: siGithub,
-    x: siX,
-    qiita: siQiita,
-  };
 
   return (
     <footer id="contact" className="bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800">
@@ -42,7 +34,8 @@ export function Footer() {
           {/* SNSリンク */}
           <div className="flex justify-center items-center gap-6 mb-8">
             {profile.socialLinks.map((link) => {
-              const icon = socialIcons[link.platform as SocialPlatform];
+              const config = SOCIAL_PLATFORM_CONFIG[link.platform];
+              if (!config) return null;
 
               return (
                 <Link
@@ -51,12 +44,12 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
-                  aria-label={link.platform}
-                  title={link.platform}
+                  aria-label={config.label}
+                  title={config.label}
                 >
                   <div
                     className="w-6 h-6"
-                    dangerouslySetInnerHTML={{ __html: icon.svg }}
+                    dangerouslySetInnerHTML={{ __html: config.icon.svg }}
                     style={{ fill: 'currentColor' }}
                   />
                 </Link>

--- a/lib/social-platforms.ts
+++ b/lib/social-platforms.ts
@@ -1,0 +1,13 @@
+import { siGithub, siX, siQiita, siZenn } from 'simple-icons'
+import type { SocialPlatform } from '@/types'
+
+type SimpleIcon = { svg: string; title: string }
+
+export const SOCIAL_PLATFORM_CONFIG: Partial<Record<SocialPlatform, { label: string; icon: SimpleIcon }>> = {
+  github:   { label: 'GitHub', icon: siGithub },
+  x:        { label: 'X',      icon: siX },
+  qiita:    { label: 'Qiita',  icon: siQiita },
+  zenn:     { label: 'Zenn',   icon: siZenn },
+  // linkedin: simple-icons v16 では未提供のため未定義
+  // other: 汎用アイコンが存在しないため未定義
+}


### PR DESCRIPTION
## Summary

- `lib/social-platforms.ts` を新規作成し、`SOCIAL_PLATFORM_CONFIG`（label + icon）を単一の参照元として定義
- `AboutSection.tsx` / `SocialLinks.tsx` / `Footer.tsx` の各コンポーネントに散在していた `socialIcons` / `socialLabels` マッピングとローカル `SocialPlatform` 型定義を削除
- `Footer.tsx` の `aria-label` / `title` も `"github"` → `"GitHub"` など正しい表示名を参照するよう修正

## Motivation

プラットフォームの表示名（label）とアイコン（icon）が3コンポーネントに重複定義されており、新プラットフォーム追加時に複数ファイルを修正する必要があった。また CSS `uppercase`/`capitalize` で補っていた表示名が `GitHub` のような固有の大文字表記に対応できない設計上の問題があった。

## Test plan

- [ ] `pnpm type-check` エラーなし
- [ ] ホームページ About セクションのボタンに "GitHub" / "Qiita" / "X" が正しく表示される
- [ ] About ページ Connect セクションのボタン表示確認
- [ ] フッターのアイコン表示に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)